### PR TITLE
Add logging output channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
                     "dark": "./icons/refresh-dark.svg",
                     "light": "./icons/refresh-light.svg"
                 }
+            },
+            {
+                "category": "Bazel",
+                "command": "bazel.showExtensionLog",
+                "title": "Show Extension Log"
             }
         ],
         "configuration": {
@@ -96,6 +101,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Whether to automatically apply lint fixes from buildifier when formatting a Bazel file."
+                },
+                "bazel.showExtensionLog": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Show the VSCode-Bazel output channel when the Bazel extension initializes."
                 }
             }
         },

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -15,7 +15,6 @@
 import * as vscode from "vscode";
 import * as which from "which";
 
-import { build } from "protobufjs";
 import {
   BazelWorkspaceInfo,
   createBazelTask,
@@ -23,7 +22,6 @@ import {
   getBazelTaskInfo,
   getDefaultBazelExecutablePath,
   IBazelCommandAdapter,
-  IBazelCommandOptions,
   parseExitCode,
   queryQuickPickPackage,
   queryQuickPickTargets,
@@ -34,6 +32,7 @@ import {
   getDefaultBuildifierExecutablePath,
 } from "../buildifier";
 import { BazelBuildCodeLensProvider } from "../codelens";
+import { setupLoggingOutputChannel } from "../logging";
 import { BazelTargetSymbolProvider } from "../symbols";
 import { BazelWorkspaceTreeProvider } from "../workspace-tree";
 
@@ -44,6 +43,8 @@ import { BazelWorkspaceTreeProvider } from "../workspace-tree";
  * @param context The extension context.
  */
 export function activate(context: vscode.ExtensionContext) {
+  setupLoggingOutputChannel(context);
+
   const workspaceTreeProvider = new BazelWorkspaceTreeProvider(context);
   const codeLensProvider = new BazelBuildCodeLensProvider(context);
   const buildifierDiagnostics = new BuildifierDiagnosticsManager();

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -1,0 +1,15 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from "./logging";

--- a/src/logging/logging.ts
+++ b/src/logging/logging.ts
@@ -1,0 +1,53 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as vscode from "vscode";
+
+/**
+ * Allows logging to the custom output channel "VSCode-Bazel".
+ */
+let logOutputChannel: vscode.OutputChannel | undefined;
+
+/**
+ * Sets up the VSCode-Bazel logging output channel and the showExtensionLog
+ * command.
+ * @param context The extension context.
+ */
+export function setupLoggingOutputChannel(context: vscode.ExtensionContext) {
+  // Setup the output channel for logging.
+  logOutputChannel = vscode.window.createOutputChannel("VSCode-Bazel");
+  context.subscriptions.push(logOutputChannel);
+  context.subscriptions.push(
+    vscode.commands.registerCommand("bazel.showExtensionLog", () =>
+      logOutputChannel.show(),
+    ),
+  );
+  const bazelConfig = vscode.workspace.getConfiguration("bazel");
+  const showExtensionLog = bazelConfig.get<boolean>("showExtensionLog");
+  if (showExtensionLog) {
+    logOutputChannel.show();
+  }
+}
+
+/**
+ * Logs a string to the output channel.
+ * @param message The string to be logged.
+ */
+export function bazelLog(message: string, newline: boolean = true) {
+  if (newline) {
+    logOutputChannel.appendLine(message);
+  } else {
+    logOutputChannel.append(message);
+  }
+}


### PR DESCRIPTION
Creates a logging output channel called "VSCode-Bazel". Components can then log to this channel to show debug information.

Adds a new command: "Show Extension Log" which will display the channel.

Also adds a new settings: "bazel.showExtensionLog" which will automatically display the output channel when the plugin initializes.